### PR TITLE
Docs: Added command for installation Boost on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Building Bitcoin2X Core
     sudo add-apt-repository ppa:bitcoin/bitcoin
     sudo apt-get update
     sudo apt-get install libdb4.8-dev libdb4.8++-dev
+    sudo apt-get install libboost-all-dev
 
     # To build the Qt GUI:
     sudo apt-get install libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libprotobuf-dev protobuf-compiler


### PR DESCRIPTION
Added command for installation Boost on Ubuntu, since its required for Make