### PR TITLE
Increase the max amount of coins for the premine

### DIFF
--- a/src/amount.h
+++ b/src/amount.h
@@ -23,7 +23,9 @@ static const CAmount CENT = 1000000;
  * critical; in unusual circumstances like a(nother) overflow bug that allowed
  * for the creation of coins out of thin air modification could lead to a fork.
  * */
-static const CAmount MAX_MONEY = 21000000 * COIN;
+
+// 21000000 + 2000000 (Premine)
+static const CAmount MAX_MONEY = 23000000 * COIN;
 inline bool MoneyRange(const CAmount& nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
 
 #endif //  BITCOIN_AMOUNT_H


### PR DESCRIPTION
Originally, the max amount of coins was 21000000.
The premine is 2000000.